### PR TITLE
Add password encryption service logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "type": "module",
     "scripts": {
         "start": "node index.js",
-        "dev": "nodemon index.js"
+        "dev": "nodemon index.js",
+        "test": "NODE_ENV=test node --test"
     },
     "keywords": [
         "manager",

--- a/src/db/prisma.js
+++ b/src/db/prisma.js
@@ -1,5 +1,9 @@
-import { PrismaClient } from '@prisma/client';
-
-const prisma = new PrismaClient();
+let prisma;
+if (process.env.NODE_ENV === 'test') {
+    prisma = {};
+} else {
+    const { PrismaClient } = await import('@prisma/client');
+    prisma = new PrismaClient();
+}
 
 export default prisma;

--- a/src/services/passwordService.js
+++ b/src/services/passwordService.js
@@ -1,12 +1,20 @@
 import passwordRepository from '../repositories/passwordRepository.js';
+import { encrypt, decrypt } from '../utils/encryption.js';
 
 class PasswordService {
     async getPasswords(vaultId, userId) {
-        return await passwordRepository.getPasswords(vaultId, userId);
+        const records = await passwordRepository.getPasswords(vaultId, userId);
+        return records.map(r => {
+            if (r.password) {
+                return { ...r, password: decrypt(r.password) };
+            }
+            return r;
+        });
     }
 
     async createPassword(vaultId, userId, name, password, username, type) {
-        return await passwordRepository.createPassword(vaultId, userId, name, password, username, type);
+        const encrypted = encrypt(password);
+        return await passwordRepository.createPassword(vaultId, userId, name, encrypted, username, type);
     }
 
     async updatePassword(vaultId, passwordId, userId, name, password, username, type) {

--- a/test/passwordService.test.js
+++ b/test/passwordService.test.js
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+process.env.ENCRYPTION_KEY = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+const { encrypt, decrypt } = await import('../src/utils/encryption.js');
+const passwordService = (await import('../src/services/passwordService.js')).default;
+const passwordRepository = (await import('../src/repositories/passwordRepository.js')).default;
+
+test('createPassword encrypts password before saving', async () => {
+  let savedPassword;
+  passwordRepository.createPassword = async (vaultId, userId, name, password, username, type) => {
+    savedPassword = password;
+    return { id: 1, name, username, type, createdAt: new Date() };
+  };
+
+  await passwordService.createPassword(1, 2, 'Example', 'plain', 'user', 'type');
+
+  assert.notEqual(savedPassword, 'plain');
+  assert.equal(decrypt(savedPassword), 'plain');
+});
+
+test('getPasswords decrypts retrieved passwords', async () => {
+  const encrypted = encrypt('secret');
+  passwordRepository.getPasswords = async () => [{ id: 1, name: 'Example', username: 'user', type: 'type', createdAt: new Date(), password: encrypted }];
+
+  const results = await passwordService.getPasswords(1, 2);
+
+  assert.equal(results[0].password, 'secret');
+});


### PR DESCRIPTION
## Summary
- encrypt passwords before saving
- decrypt passwords when retrieving
- support running unit tests
- provide simple tests for encryption logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684107d32af4832cba7a6b441926028c