### PR TITLE
Refactor repositories to accept Prisma client

### DIFF
--- a/src/repositories/passwordRepository.js
+++ b/src/repositories/passwordRepository.js
@@ -1,8 +1,9 @@
-import prisma from '../db/prisma.js';
-
 class PasswordRepository {
+    constructor(prisma) {
+        this.prisma = prisma;
+    }
     async getPasswords(vaultId, userId) {
-        return await prisma.password.findMany({
+        return await this.prisma.password.findMany({
             where: {
                 vaultId,
                 userId,
@@ -18,7 +19,7 @@ class PasswordRepository {
     }
 
     async createPassword(vaultId, userId, name, password, username, type) {
-        return await prisma.password.create({
+        return await this.prisma.password.create({
             data: {
                 vaultId,
                 userId,
@@ -38,7 +39,7 @@ class PasswordRepository {
     }
 
     async updatePassword(vaultId, passwordId, userId, name, password, username, type) {
-        const updated = await prisma.password.updateMany({
+        const updated = await this.prisma.password.updateMany({
             where: {
                 id: passwordId,
                 vaultId,
@@ -52,7 +53,7 @@ class PasswordRepository {
             },
         });
         if (!updated.count) return null;
-        return await prisma.password.findUnique({
+        return await this.prisma.password.findUnique({
             where: { id: passwordId },
             select: {
                 id: true,
@@ -65,7 +66,7 @@ class PasswordRepository {
     }
 
     async deletePassword(vaultId, passwordId, userId) {
-        return await prisma.password.deleteMany({
+        return await this.prisma.password.deleteMany({
             where: {
                 id: passwordId,
                 vaultId,
@@ -75,4 +76,4 @@ class PasswordRepository {
     }
 }
 
-export default new PasswordRepository();
+export default PasswordRepository;

--- a/src/repositories/userRepository.js
+++ b/src/repositories/userRepository.js
@@ -1,8 +1,10 @@
-import prisma from '../db/prisma.js';
-
 class UserRepository {
+    constructor(prisma) {
+        this.prisma = prisma;
+    }
+
     async createUser(email, hashedPassword) {
-        return await prisma.user.create({
+        return await this.prisma.user.create({
             data: {
                 email,
                 password: hashedPassword,
@@ -15,10 +17,10 @@ class UserRepository {
     }
 
     async findUserByEmail(email) {
-        return await prisma.user.findUnique({
+        return await this.prisma.user.findUnique({
             where: { email },
         });
     }
 }
 
-export default new UserRepository();
+export default UserRepository;

--- a/src/repositories/vaultRepository.js
+++ b/src/repositories/vaultRepository.js
@@ -1,8 +1,10 @@
-import prisma from '../db/prisma.js';
-
 class VaultRepository {
+    constructor(prisma) {
+        this.prisma = prisma;
+    }
+
     async insertVault(userId, name, userEmail) {
-        return await prisma.vault.create({
+        return await this.prisma.vault.create({
             data: {
                 userId,
                 name,
@@ -18,7 +20,7 @@ class VaultRepository {
     }
 
     async fetchVaultsByUserId(userId) {
-        return await prisma.vault.findMany({
+        return await this.prisma.vault.findMany({
             where: { userId },
             select: {
                 id: true,
@@ -30,7 +32,7 @@ class VaultRepository {
     }
 
     async fetchSharedUsersByVaultId(vaultId) {
-        const records = await prisma.vaultUser.findMany({
+        const records = await this.prisma.vaultUser.findMany({
             where: { vaultId },
             include: {
                 user: {
@@ -42,7 +44,7 @@ class VaultRepository {
     }
 
     async fetchVaultByIdAndUserId(vaultId, userId) {
-        return await prisma.vault.findFirst({
+        return await this.prisma.vault.findFirst({
             where: {
                 id: vaultId,
                 OR: [
@@ -54,7 +56,7 @@ class VaultRepository {
     }
 
     async fetchVaultByIdAndOwnerId(vaultId, userId) {
-        return await prisma.vault.findFirst({
+        return await this.prisma.vault.findFirst({
             where: {
                 id: vaultId,
                 userId,
@@ -63,19 +65,19 @@ class VaultRepository {
     }
 
     async deleteVaultAndAssociations(vaultId) {
-        return await prisma.$transaction([
-            prisma.password.deleteMany({ where: { vaultId } }),
-            prisma.vaultUser.deleteMany({ where: { vaultId } }),
-            prisma.vault.delete({ where: { id: vaultId } }),
+        return await this.prisma.$transaction([
+            this.prisma.password.deleteMany({ where: { vaultId } }),
+            this.prisma.vaultUser.deleteMany({ where: { vaultId } }),
+            this.prisma.vault.delete({ where: { id: vaultId } }),
         ]);
     }
 
     async fetchUserByEmail(email) {
-        return await prisma.user.findUnique({ where: { email } });
+        return await this.prisma.user.findUnique({ where: { email } });
     }
 
     async insertVaultUser(vaultId, userId) {
-        return await prisma.vaultUser.create({
+        return await this.prisma.vaultUser.create({
             data: {
                 vaultId,
                 userId,
@@ -84,11 +86,11 @@ class VaultRepository {
     }
 
     async fetchPasswordsByVaultId(vaultId) {
-        return await prisma.password.findMany({
+        return await this.prisma.password.findMany({
             where: { vaultId },
             select: { name: true, password: true },
         });
     }
 }
 
-export default new VaultRepository();
+export default VaultRepository;

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -1,17 +1,22 @@
 import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
-import userRepository from '../repositories/userRepository.js';
+import prisma from '../db/prisma.js';
+import UserRepository from '../repositories/userRepository.js';
 
 class AuthService {
+    constructor(userRepository = new UserRepository(prisma)) {
+        this.userRepository = userRepository;
+    }
+
     async registerUser(email, password) {
         const hashedPassword = await bcrypt.hash(password, 10);
-        const user = await userRepository.createUser(email, hashedPassword);
+        const user = await this.userRepository.createUser(email, hashedPassword);
         const token = jwt.sign({ id: user.id, email: user.email }, process.env.AUTH_KEY, { expiresIn: '1h' });
         return { token, user };
     }
 
     async loginUser(email, password) {
-        const user = await userRepository.findUserByEmail(email);
+        const user = await this.userRepository.findUserByEmail(email);
         if (!user) {
             throw new Error('User not found');
         }
@@ -26,4 +31,5 @@ class AuthService {
     }
 }
 
+export { AuthService };
 export default new AuthService();

--- a/src/services/passwordService.js
+++ b/src/services/passwordService.js
@@ -1,9 +1,14 @@
-import passwordRepository from '../repositories/passwordRepository.js';
+import prisma from '../db/prisma.js';
+import PasswordRepository from '../repositories/passwordRepository.js';
 import { encrypt, decrypt } from '../utils/encryption.js';
 
 class PasswordService {
+    constructor(passwordRepository = new PasswordRepository(prisma)) {
+        this.passwordRepository = passwordRepository;
+    }
+
     async getPasswords(vaultId, userId) {
-        const records = await passwordRepository.getPasswords(vaultId, userId);
+        const records = await this.passwordRepository.getPasswords(vaultId, userId);
         return records.map(r => {
             if (r.password) {
                 return { ...r, password: decrypt(r.password) };
@@ -14,16 +19,17 @@ class PasswordService {
 
     async createPassword(vaultId, userId, name, password, username, type) {
         const encrypted = encrypt(password);
-        return await passwordRepository.createPassword(vaultId, userId, name, encrypted, username, type);
+        return await this.passwordRepository.createPassword(vaultId, userId, name, encrypted, username, type);
     }
 
     async updatePassword(vaultId, passwordId, userId, name, password, username, type) {
-        return await passwordRepository.updatePassword(vaultId, passwordId, userId, name, password, username, type);
+        return await this.passwordRepository.updatePassword(vaultId, passwordId, userId, name, password, username, type);
     }
 
     async deletePassword(vaultId, passwordId, userId) {
-        return await passwordRepository.deletePassword(vaultId, passwordId, userId);
+        return await this.passwordRepository.deletePassword(vaultId, passwordId, userId);
     }
 }
 
+export { PasswordService };
 export default new PasswordService();

--- a/src/services/vaultService.js
+++ b/src/services/vaultService.js
@@ -1,14 +1,19 @@
-import vaultRepository from '../repositories/vaultRepository.js';
+import prisma from '../db/prisma.js';
+import VaultRepository from '../repositories/vaultRepository.js';
 
 class VaultService {
+    constructor(vaultRepository = new VaultRepository(prisma)) {
+        this.vaultRepository = vaultRepository;
+    }
+
     async insertVault(userId, name, userEmail) {
-        return await vaultRepository.insertVault(userId, name, userEmail);
+        return await this.vaultRepository.insertVault(userId, name, userEmail);
     }
 
     async fetchVaultsWithSharedInfo(userId) {
-        const vaults = await vaultRepository.fetchVaultsByUserId(userId);
+        const vaults = await this.vaultRepository.fetchVaultsByUserId(userId);
         return await Promise.all(vaults.map(async vault => {
-            const sharedUsers = await vaultRepository.fetchSharedUsersByVaultId(vault.id);
+            const sharedUsers = await this.vaultRepository.fetchSharedUsersByVaultId(vault.id);
             return {
                 ...vault,
                 sharedWith: sharedUsers.map(user => user.email),
@@ -17,11 +22,11 @@ class VaultService {
     }
 
     async fetchVaultWithSharedInfoById(vaultId, userId) {
-        const vault = await vaultRepository.fetchVaultByIdAndUserId(vaultId, userId);
+        const vault = await this.vaultRepository.fetchVaultByIdAndUserId(vaultId, userId);
         if (!vault) {
             return null;
         }
-        const sharedUsers = await vaultRepository.fetchSharedUsersByVaultId(vault.id);
+        const sharedUsers = await this.vaultRepository.fetchSharedUsersByVaultId(vault.id);
         return {
             ...vault,
             sharedWith: sharedUsers.map(user => user.email),
@@ -29,32 +34,33 @@ class VaultService {
     }
 
     async fetchVaultByIdAndUserId(vaultId, userId) {
-        return await vaultRepository.fetchVaultByIdAndUserId(vaultId, userId);
+        return await this.vaultRepository.fetchVaultByIdAndUserId(vaultId, userId);
     }
 
     async fetchVaultByOwnerId(vaultId, userId) {
-        return await vaultRepository.fetchVaultByIdAndOwnerId(vaultId, userId);
+        return await this.vaultRepository.fetchVaultByIdAndOwnerId(vaultId, userId);
     }
 
     async deleteVaultAndAssociations(vaultId) {
-        return await vaultRepository.deleteVaultAndAssociations(vaultId);
+        return await this.vaultRepository.deleteVaultAndAssociations(vaultId);
     }
 
     async fetchUserByEmail(email) {
-        return await vaultRepository.fetchUserByEmail(email);
+        return await this.vaultRepository.fetchUserByEmail(email);
     }
 
     async insertVaultUser(vaultId, userId) {
-        return await vaultRepository.insertVaultUser(vaultId, userId);
+        return await this.vaultRepository.insertVaultUser(vaultId, userId);
     }
 
     async fetchVaultPasswords(vaultId, userId) {
-        const vault = await vaultRepository.fetchVaultByIdAndUserId(vaultId, userId);
+        const vault = await this.vaultRepository.fetchVaultByIdAndUserId(vaultId, userId);
         if (!vault) {
             return null;
         }
-        return await vaultRepository.fetchPasswordsByVaultId(vaultId);
+        return await this.vaultRepository.fetchPasswordsByVaultId(vaultId);
     }
 }
 
+export { VaultService };
 export default new VaultService();

--- a/test/passwordService.test.js
+++ b/test/passwordService.test.js
@@ -3,17 +3,19 @@ import assert from 'node:assert/strict';
 
 process.env.ENCRYPTION_KEY = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
 const { encrypt, decrypt } = await import('../src/utils/encryption.js');
-const passwordService = (await import('../src/services/passwordService.js')).default;
-const passwordRepository = (await import('../src/repositories/passwordRepository.js')).default;
+const { PasswordService } = await import('../src/services/passwordService.js');
 
 test('createPassword encrypts password before saving', async () => {
   let savedPassword;
-  passwordRepository.createPassword = async (vaultId, userId, name, password, username, type) => {
-    savedPassword = password;
-    return { id: 1, name, username, type, createdAt: new Date() };
+  const mockRepository = {
+    createPassword: async (vaultId, userId, name, password, username, type) => {
+      savedPassword = password;
+      return { id: 1, name, username, type, createdAt: new Date() };
+    }
   };
+  const service = new PasswordService(mockRepository);
 
-  await passwordService.createPassword(1, 2, 'Example', 'plain', 'user', 'type');
+  await service.createPassword(1, 2, 'Example', 'plain', 'user', 'type');
 
   assert.notEqual(savedPassword, 'plain');
   assert.equal(decrypt(savedPassword), 'plain');
@@ -21,9 +23,12 @@ test('createPassword encrypts password before saving', async () => {
 
 test('getPasswords decrypts retrieved passwords', async () => {
   const encrypted = encrypt('secret');
-  passwordRepository.getPasswords = async () => [{ id: 1, name: 'Example', username: 'user', type: 'type', createdAt: new Date(), password: encrypted }];
+  const mockRepository = {
+    getPasswords: async () => [{ id: 1, name: 'Example', username: 'user', type: 'type', createdAt: new Date(), password: encrypted }]
+  };
+  const service = new PasswordService(mockRepository);
 
-  const results = await passwordService.getPasswords(1, 2);
+  const results = await service.getPasswords(1, 2);
 
   assert.equal(results[0].password, 'secret');
 });


### PR DESCRIPTION
## Summary
- inject Prisma client via repository constructors
- instantiate repositories within services
- expose service classes for easier testing
- update unit tests to use mocked repositories

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68410ab5f6c0832cac94db1bf4e92f5c